### PR TITLE
QTBOT-43 - Improved BotScript database connection logic. 

### DIFF
--- a/bot/bot.cpp
+++ b/bot/bot.cpp
@@ -31,9 +31,8 @@ Bot::reloadAllCommands() {
 
 void
 Bot::run(QSharedPointer<Settings> settings) {
-    QString scriptDir = settings->value(SettingsParam::Script::SCRIPT_DIRECTORY).toString();
-    QString botToken  = settings->value(SettingsParam::Connection::BOT_TOKEN).toString();
-    _factory = new CommandFactory(this, scriptDir, botToken);
+
+    _factory = new CommandFactory(this, settings);
 
     Gateway *connection = new Gateway(settings);
     connection->moveToThread(&_gatewayThread);

--- a/bot/bot.pri
+++ b/bot/bot.pri
@@ -5,6 +5,7 @@ DEPENDPATH += $$PWD/.
 
 
 HEADERS += \
+    $$PWD/botjob/databasecontext.h \
     $$PWD/botjob/job.h \
     $$PWD/botjob/jobqueue.h \
     $$PWD/entitymanager.h \
@@ -81,6 +82,7 @@ DISTFILES += \
 
 SOURCES += \
     $$PWD/bot.cpp \
+    $$PWD/botjob/databasecontext.cpp \
     $$PWD/botjob/job.cpp \
     $$PWD/botjob/jobqueue.cpp \
     $$PWD/entitymanager.cpp \

--- a/bot/botjob/databasecontext.cpp
+++ b/bot/botjob/databasecontext.cpp
@@ -1,0 +1,33 @@
+#include "databasecontext.h"
+
+#include "util/globals.h"
+#include "util/enumutils.h"
+
+DatabaseContext::DatabaseContext(QSharedPointer<Settings> settings) {
+    hostName = settings->value(SettingsParam::Database::DATABASE_HOST).toString();
+
+    port = settings->value(SettingsParam::Database::DATABASE_PORT).toInt();
+
+    userName = settings->value(SettingsParam::Database::DATABASE_USER).toString();
+
+    password = settings->value(SettingsParam::Database::DATABASE_PASSWORD).toString();
+
+    driverName = settings->value(SettingsParam::Database::DATABASE_TYPE).toString();
+
+    type = EnumUtils::keyToValue<SettingsParam::Database::DatabaseType>(driverName);
+
+    databaseName = settings->value(SettingsParam::Database::DATABASE_NAME).toString();
+}
+
+void
+DatabaseContext::setConnectionName(const QString &scriptName, const QString &guildId) {
+    _connectionName = QString("%1|%2|%3")
+            .arg(scriptName)
+            .arg(guildId)
+            .arg(type);
+}
+
+QString
+DatabaseContext::getConnectionName() const {
+    return _connectionName;
+}

--- a/bot/botjob/databasecontext.h
+++ b/bot/botjob/databasecontext.h
@@ -1,0 +1,29 @@
+#ifndef DATABASECONTEXT_H
+#define DATABASECONTEXT_H
+
+#include <QSharedPointer>
+
+#include "util/settings.h"
+
+
+class DatabaseContext
+{       
+    QString _connectionName;
+
+public:
+    int port;
+    int type;
+    QString hostName;
+    QString userName;
+    QString password;
+    QString databaseName;
+    QString driverName;
+
+    DatabaseContext() {}
+    DatabaseContext(QSharedPointer<Settings> settings);
+    ~DatabaseContext() {}
+    void setConnectionName(const QString &scriptName, const QString &guildId);
+    QString getConnectionName() const;
+};
+
+#endif // DATABASECONTEXT_H

--- a/bot/botjob/ibotjob.h
+++ b/bot/botjob/ibotjob.h
@@ -7,6 +7,8 @@
 #include "payloads/eventcontext.h"
 
 class IBotJob {
+
+protected:
     QString _guildId;
 
 public:

--- a/bot/botjob/job.cpp
+++ b/bot/botjob/job.cpp
@@ -7,7 +7,7 @@ Job::commandMapping() const {
 }
 
 QString
-Job::guildId() {
+Job::guildId() const {
     return _commandMapping.second->guildId();
 }
 

--- a/bot/botjob/job.h
+++ b/bot/botjob/job.h
@@ -15,7 +15,7 @@ public:
     bool invokable() const;
     EventContext context() const;
     IBotJob::CommandMapping commandMapping() const;
-    QString guildId();
+    QString guildId() const;
     void run() override;
     void setCommandMapping(const IBotJob::CommandMapping &commandMapping);
     void setContext(const EventContext &context);

--- a/bot/qml/commandfactory.cpp
+++ b/bot/qml/commandfactory.cpp
@@ -117,6 +117,9 @@ CommandFactory::loadScriptComponent(const QString &fileName) {
             _logger->warning(QString("Commmand \"%1\" already registered to bot script named: %2")
                         .arg(command).arg(existingScript));
         } else {
+            botScript->setDatabaseContext(_defaultDatabaseContext);
+
+            botScript->setConnectionName();
 
             QString mapping = botScript->findCommandMapping(command);
 

--- a/bot/qml/commandfactory.h
+++ b/bot/qml/commandfactory.h
@@ -19,6 +19,7 @@ class CommandFactory : public QObject
     Bot *_bot;
     Logger *_logger;
 
+    DatabaseContext _defaultDatabaseContext;
     QQmlApplicationEngine _engine;
     QString _botToken;
     QString _guildId;
@@ -43,14 +44,16 @@ public:
     CommandFactory() {}
     CommandFactory(const CommandFactory &other) { Q_UNUSED(other) }
     ~CommandFactory() {}
-    CommandFactory(Bot *bot, const QString &scriptDir, const QString &botToken) {
+    CommandFactory(Bot *bot, QSharedPointer<Settings> settings)
+        : _defaultDatabaseContext(settings) {
+
         _bot = bot;
 
         _logger = LogFactory::getLogger();
 
-        _scriptDir = scriptDir;
+        _scriptDir = settings->value(SettingsParam::Script::SCRIPT_DIRECTORY).toString();
 
-        _botToken = botToken;
+        _botToken = settings->value(SettingsParam::Connection::BOT_TOKEN).toString();;
 
         _engine.installExtensions(QJSEngine::ConsoleExtension);
 

--- a/bot/settings.ini
+++ b/bot/settings.ini
@@ -70,10 +70,10 @@ script_directory =
 # This is the type of database used for persisting guild (server) configuration data.
 #
 # Possible Values:
-#   SQLITE (requires no additional backend database)
-#   MSSQL_SERVER
-#   ORACLE
-#   POSTGRES
+#   QSQLITE     -> SQLite (requires no additional backend database)
+#   QODBC       -> MSSQL Server
+#   QMYSQL      -> MySQL/MariaDB
+#   QPSQL       -> Postgres
 #
 # Default is SQLITE
 #
@@ -115,11 +115,21 @@ database_user =
 #
 # !!NOT APPLICABLE FOR SQLITE!!
 #
-# This the passfor for the given user for the specified database server.
+# This is the password for for the given user for the specified database server.
 #
 # REQUIRED
 
 database_password =
+
+# database_name
+#
+# !!NOT APPLICABLE FOR SQLITE!!
+#
+# This is the default database name for the for the specified database server.
+#
+# REQUIRED
+
+database_name =
 
 
 # --------------------------------------------------------------

--- a/bot/util/globals.h
+++ b/bot/util/globals.h
@@ -52,14 +52,15 @@ static const QString DATABASE_USER = "database_user";
 //TODO PASSWORD HASH?
 static const QString DATABASE_PASSWORD = "database_password";
 static const QString DATABASE_TYPE = "database_type";
+static const QString DATABASE_NAME = "database_name";
 
-enum DatabaseTypes {
-    SQLITE = 0,
-    MSSQLSERVER,
-    MYSQL,
-    POSTGRES
+enum DatabaseType {
+    QSQLITE = 0,
+    QODBC,
+    QMYSQL,
+    QPSQL
 };
-Q_ENUM_NS(DatabaseTypes)
+Q_ENUM_NS(DatabaseType)
 }
 }
 

--- a/bot/util/settings.cpp
+++ b/bot/util/settings.cpp
@@ -3,8 +3,7 @@
 #include <QMetaEnum>
 #include <QDir>
 
-#include <logging/logcontext.h>
-
+#include "logging/logcontext.h"
 #include "settings.h"
 #include "globals.h"
 
@@ -79,17 +78,17 @@ Settings::validateScriptSettings() {
 void
 Settings::validateDatabaseSettings() {
     if (_settings[SettingsParam::Database::DATABASE_TYPE].toString().isEmpty()) {
-        _settings[SettingsParam::Database::DATABASE_TYPE] = SettingsParam::Database::DatabaseTypes::SQLITE;
+        _settings[SettingsParam::Database::DATABASE_TYPE] = SettingsParam::Database::DatabaseType::QSQLITE;
     }
 
-    QMetaEnum metaEnum = QMetaEnum::fromType<SettingsParam::Database::DatabaseTypes>();
+    QMetaEnum metaEnum = QMetaEnum::fromType<SettingsParam::Database::DatabaseType>();
     QString databaseType = _settings[SettingsParam::Database::DATABASE_TYPE].toString();
     int typeValue = metaEnum.keyToValue(databaseType.toUpper().toStdString().c_str());
     if (typeValue < 0) {
         invalidEnumValue(SettingsParam::Database::DATABASE_TYPE, databaseType, metaEnum);
     }
 
-    if (typeValue != SettingsParam::Database::DatabaseTypes::SQLITE) {
+    if (typeValue != SettingsParam::Database::DatabaseType::QSQLITE) {
         if (_settings[SettingsParam::Database::DATABASE_HOST].toString().isEmpty()) {
             invalidDatabaseProperty(databaseType, SettingsParam::Database::DATABASE_HOST);
         }
@@ -104,6 +103,10 @@ Settings::validateDatabaseSettings() {
 
         if (_settings[SettingsParam::Database::DATABASE_PASSWORD].toString().isEmpty()) {
             invalidDatabaseProperty(databaseType, SettingsParam::Database::DATABASE_PASSWORD);
+        }
+
+        if (_settings[SettingsParam::Database::DATABASE_NAME].toString().isEmpty()) {
+            invalidDatabaseProperty(databaseType, SettingsParam::Database::DATABASE_NAME);
         }
     }
 }


### PR DESCRIPTION
`dbOpen()` now opens fresh connection instead of reusing potentially dead connection.

Each **BotScript** will now have a default `DatabaseContext` containing relevant DB connection information.

The default context will contain the database information entered into `settings.ini`

`BotScripts` now just have to call `dbOpen()` to open a fresh database connection using the database parameters from `settings.ini`

BotScripts can now modify their own DatabaseContext via the standard `dbSetHost(hostname)`, etc, if you need to specify some other database for the script to pull from.