### PR TITLE
QTBOT-48 - old command/gateway bindings are now correcly cleared on reload.

### DIFF
--- a/bot/botjob/scriptbuilder.cpp
+++ b/bot/botjob/scriptbuilder.cpp
@@ -31,6 +31,8 @@ ScriptBuilder::buildCommands(QSharedPointer<GuildEntity> guildEntity) {
 
     _scriptNameByCommand.clear();
 
+    _functionNameByEventNameByScriptName.clear();
+
     _guildId = guildEntity->id();
 
     loadCoreCommands();

--- a/bot/entity/guildentity.cpp
+++ b/bot/entity/guildentity.cpp
@@ -126,6 +126,8 @@ GuildEntity::setId(const QString &id) {
 
 void
 GuildEntity::setCommandBindings(const QList<CommandBinding> &commandBindings) {
+    _commandBindings.clear();
+
     for (auto binding : commandBindings) {
         _commandBindings[binding.getCommandName()] = binding;
     }
@@ -133,9 +135,12 @@ GuildEntity::setCommandBindings(const QList<CommandBinding> &commandBindings) {
 
 void
 GuildEntity::setGatewayBindings(const QList<GatewayBinding> &gatewayBindings) {
+    _gatewayBindings.clear();
+
     for (auto binding : gatewayBindings) {
         if (_gatewayBindings.contains(binding.getEventName())) {
             _gatewayBindings[binding.getEventName()] << binding;
+
         } else {
             _gatewayBindings[binding.getEventName()] = QList<GatewayBinding>() << binding;
         }


### PR DESCRIPTION
Dangling references to deleted script components were not getting cleared when `.reload` command was issued.