### PR TITLE
QTBOT-63 - fixed program crash from nullptr from script generated timed events

### DIFF
--- a/bot/botjob/botscript.cpp
+++ b/bot/botjob/botscript.cpp
@@ -108,7 +108,7 @@ BotScript::queueTimedEvent(const QVariant &timedBindingVariant) {
 
     QSharedPointer<TimedBinding> timedBinding = QSharedPointer<TimedBinding>(new TimedBinding);
 
-    timedBinding->setFunctionMapping(qMakePair(binding[TimedBinding::FUNCTION].toString(), QSharedPointer<BotScript>(this)));
+    timedBinding->setFunctionMapping(qMakePair(binding[TimedBinding::FUNCTION].toString(), this));
 
     timedBinding->setScriptName(_scriptName);
 

--- a/bot/botjob/corecommands.h
+++ b/bot/botjob/corecommands.h
@@ -12,17 +12,17 @@ class CoreCommands {
 
 public:
 
-    static QList<CommandBinding> buildCoreCommandBindings(EventHandler &eventHandler, const QString &guildId) {
-        QList<CommandBinding> commands;
+    static QMap<QSharedPointer<CoreCommand>, CommandBinding> buildCoreCommandBindings(EventHandler &eventHandler, const QString &guildId) {
+        QMap<QSharedPointer<CoreCommand>, CommandBinding> commands;
 
         const auto addCommand = [&](auto commandName, auto cmd) {
             QSharedPointer<CoreCommand> coreCommand = QSharedPointer<CoreCommand>(new CoreCommand(cmd));
 
             coreCommand->setGuildId(guildId);
 
-            IBotJob::FunctionMapping functionMapping = qMakePair(commandName, coreCommand);
+            IBotJob::FunctionMapping functionMapping = qMakePair(commandName, coreCommand.data());
 
-            commands << CommandBinding(commandName, functionMapping);
+            commands[coreCommand] = CommandBinding(commandName, functionMapping);
         };
 
         addCommand(".reload", [&](const EventContext &context) -> void {

--- a/bot/botjob/ibinding.cpp
+++ b/bot/botjob/ibinding.cpp
@@ -9,10 +9,10 @@ const QString IBinding::FUNCTION = "function";
 const QString IBinding::DESCRIPTION = "description";
 
 bool IBinding::validateFunctionMapping(const QMetaObject &metaObject) const {
-    if (_functionMapping.first.isEmpty() || _functionMapping.second.isNull()) {
+    if (_functionMapping.first.isEmpty() || !_functionMapping.second) {
         _logger->warning(QString("Invalid command mapping. First: %1, Second: %2... Discarding binding.")
                          .arg(_functionMapping.first.isEmpty() )
-                         .arg(_functionMapping.second.isNull() ? "nullptr" : _functionMapping.second->objectName()));
+                         .arg(!_functionMapping.second ? "nullptr" : _functionMapping.second->objectName()));
 
         return false;
     }

--- a/bot/botjob/ibotjob.h
+++ b/bot/botjob/ibotjob.h
@@ -14,7 +14,7 @@ protected:
     QString _guildId;
 
 public:
-    typedef QPair<QString, QSharedPointer<IBotJob> > FunctionMapping;
+    typedef QPair<QString, IBotJob *> FunctionMapping;
 
     virtual bool invokable() = 0;
     virtual void execute(const QByteArray &command, const EventContext &context) = 0;

--- a/bot/botjob/scriptbuilder.h
+++ b/bot/botjob/scriptbuilder.h
@@ -29,6 +29,7 @@ class ScriptBuilder : public QObject
     QString _guildId;
     QString _scriptDir;
     QStringList _coreCommandNames;
+    QList<QSharedPointer<IBotJob> > _registeredScripts;
     QList<CommandBinding> _commandBindings;
     QList<GatewayBinding> _gatewayBindings;
     QList<TimedBinding> _timedBindings;

--- a/bot/entity/guildentity.cpp
+++ b/bot/entity/guildentity.cpp
@@ -135,6 +135,13 @@ GuildEntity::setId(const QString &id) {
 }
 
 void
+GuildEntity::setRegisteredScripts(const QList<QSharedPointer<IBotJob> > registeredScripts) {
+    _registeredScripts.clear();
+
+    _registeredScripts << registeredScripts;
+}
+
+void
 GuildEntity::setCommandBindings(const QList<CommandBinding> &commandBindings) {
     _commandBindings.clear();
 

--- a/bot/entity/guildentity.h
+++ b/bot/entity/guildentity.h
@@ -16,6 +16,7 @@ class GuildEntity : public QObject
 {
     Q_OBJECT
 
+    QList<QSharedPointer<IBotJob> > _registeredScripts;
     QList<TimedBinding> _timedBindings;
     QMap<QString, QList<GatewayBinding> > _gatewayBindings;
     QMap<QString, CommandBinding> _commandBindings;
@@ -43,9 +44,11 @@ public:
     QList<Job *> getBotJobs(QSharedPointer<EventContext> context);
     QList<TimedBinding> getTimedBindings() const;
     QString id() const;
-    void setId(const QString &id);
+
     void setCommandBindings(const QList<CommandBinding> &commandBindings);
     void setGatewayBindings(const QList<GatewayBinding> &gatewayBindings);
+    void setId(const QString &id);
+    void setRegisteredScripts(const QList<QSharedPointer<IBotJob> > registeredScripts);
     void setTimedBindings(const QList<TimedBinding> &timedBindings);
 
 private:


### PR DESCRIPTION
https://qtbot.atlassian.net/browse/QTBOT-63

Fixed the nullptr crash from a bad QSharedPointer instantiation.

IBotJobs now work on raw pointers passed from QSharedPointers which are now managed by GuildEntity.

On script reload, the old QSharedPointers will be cleared, correctly freeing the underlying botscript/core commands at the correct time.