### PR TITLE
Script refactor

### DIFF
--- a/bot/botjob/botscript.cpp
+++ b/bot/botjob/botscript.cpp
@@ -39,7 +39,9 @@ BotScript::BotScript() {
 }
 
 BotScript::~BotScript() {
-    _engine->clearComponentCache();
+    if (_engine) {
+        _engine->clearComponentCache();
+    }
 }
 
 BotScript::BotScript(const BotScript &other) {

--- a/bot/botjob/commandbinding.cpp
+++ b/bot/botjob/commandbinding.cpp
@@ -40,6 +40,8 @@ CommandBinding::CommandBinding(const CommandBinding &other) {
     _commandName = other._commandName;
 
     _adminOnly = other._adminOnly;
+
+    _ignoreAdmin = other._ignoreAdmin;
 }
 
 CommandBinding
@@ -58,17 +60,9 @@ CommandBinding
 
     _adminOnly = other._adminOnly;
 
+    _ignoreAdmin = other._ignoreAdmin;
+
     return *this;
-}
-
-bool
-CommandBinding::isAdminOnly() const {
-    return _adminOnly;
-}
-
-void
-CommandBinding::setAdminOnly(const bool adminOnly) {
-    _adminOnly = adminOnly;
 }
 
 QString

--- a/bot/botjob/commandbinding.h
+++ b/bot/botjob/commandbinding.h
@@ -26,9 +26,8 @@
 class CommandBinding : public IBinding
 {
 
-    bool _adminOnly = false;
+    bool _ignoreAdmin = false;
     QString _commandName;
-
 
 public:
     static const QString COMMAND;
@@ -41,10 +40,9 @@ public:
 
     CommandBinding &operator=(const CommandBinding &other);
 
-    bool isAdminOnly() const;
     QString getCommandName() const;
-    void setAdminOnly(const bool adminOnly);
-    void setCommandName(const QString &commandName);
+
+    void setCommandName(const QString &commandName); 
 
     bool isValid(const QMetaObject &metaObject) const override;
 };

--- a/bot/botjob/corecommands.h
+++ b/bot/botjob/corecommands.h
@@ -138,20 +138,6 @@ public:
                                       Q_ARG(EventContext, context));
         });
 
-        addCommand(".clearcommand", true, [&](const EventContext &context) -> void {
-            QMetaObject::invokeMethod(&eventHandler,
-                                      "removeRestrictionStatesForCommand",
-                                      Qt::QueuedConnection,
-                                      Q_ARG(EventContext, context));
-        });
-
-        addCommand(".clearid", true, [&](const EventContext &context) -> void {
-            QMetaObject::invokeMethod(&eventHandler,
-                                      "removeRestrictionStatesForId",
-                                      Qt::QueuedConnection,
-                                      Q_ARG(EventContext, context));
-        });
-
         return commands;
     }
 };

--- a/bot/botjob/gatewaybinding.cpp
+++ b/bot/botjob/gatewaybinding.cpp
@@ -32,6 +32,10 @@ GatewayBinding::GatewayBinding(const QString &eventName) {
 }
 
 GatewayBinding::GatewayBinding(const GatewayBinding &other) {
+    if (this == &other) {
+        return;
+    }
+
     _functionMapping = other._functionMapping;
 
     _logger = other._logger;

--- a/bot/botjob/gatewaybinding.cpp
+++ b/bot/botjob/gatewaybinding.cpp
@@ -25,6 +25,7 @@
 
 const QString GatewayBinding::GATEWAY_EVENT = "gateway_event";
 const QString GatewayBinding::SINGLETON = "singleton";
+const QString GatewayBinding::BINDING_NAME = "binding_name";
 
 GatewayBinding::GatewayBinding(const QString &eventName) {
     _eventName = eventName;
@@ -35,9 +36,13 @@ GatewayBinding::GatewayBinding(const GatewayBinding &other) {
 
     _logger = other._logger;
 
+    _ignoreAdmin = other._ignoreAdmin;
+
     _description = other._description;
 
     _eventName = other._eventName;
+
+    _bindingName = other._bindingName;
 }
 
 GatewayBinding
@@ -50,9 +55,13 @@ GatewayBinding
 
     _logger = other._logger;
 
+    _ignoreAdmin = other._ignoreAdmin;
+
     _description = other._description;
 
     _eventName = other._eventName;
+
+    _bindingName = other._bindingName;
 
     return *this;
 }
@@ -66,7 +75,21 @@ void GatewayBinding::setEventName(const QString &eventName) {
     _eventName = eventName;
 }
 
+QString
+GatewayBinding::getBindingName() {
+    return _bindingName;
+}
+
+void
+GatewayBinding::setBindingName(const QString &bindingName) {
+    _bindingName = bindingName;
+}
+
 bool GatewayBinding::isValid(const QMetaObject &metaObject) const {
+    if (!isValidParam(_bindingName)) {
+        return false;
+    }
+
     if (!validateFunctionMapping(metaObject)) {
         return false;
     }

--- a/bot/botjob/gatewaybinding.h
+++ b/bot/botjob/gatewaybinding.h
@@ -27,11 +27,13 @@
 class GatewayBinding : public IBinding
 {
     QString _eventName;
+    QString _bindingName;
 
 public:
 
     static const QString GATEWAY_EVENT;
     static const QString SINGLETON;
+    static const QString BINDING_NAME;
 
     GatewayBinding() {}
     GatewayBinding(const QString &eventType);
@@ -41,7 +43,9 @@ public:
 
     bool isValid(const QMetaObject &metaObject) const override;
     QString getEventName() const;
-    void setEventName(const QString &eventType);    
+    void setEventName(const QString &eventType);
+    QString getBindingName();
+    void setBindingName(const QString &bindingName);
 };
 
 #endif // GATEWAYBINDING_H

--- a/bot/botjob/ibinding.cpp
+++ b/bot/botjob/ibinding.cpp
@@ -27,13 +27,20 @@ const QString IBinding::BINDING_TYPE_GATEWAY = "gateway";
 const QString IBinding::BINDING_TYPE_TIMED = "timed";
 const QString IBinding::FUNCTION = "function";
 const QString IBinding::DESCRIPTION = "description";
+const QString IBinding::IGNORE_ADMIN = "ignore_admin";
 
 bool IBinding::validateFunctionMapping(const QMetaObject &metaObject) const {
+
+
     if (_functionMapping.first.isEmpty() || !_functionMapping.second) {
         _logger->warning(QString("Invalid command mapping. First: %1, Second: %2... Discarding binding.")
                          .arg(_functionMapping.first.isEmpty() )
                          .arg(!_functionMapping.second ? "nullptr" : _functionMapping.second->objectName()));
 
+        return false;
+    }
+
+    if (!isValidParam(_functionMapping.first)) {
         return false;
     }
 
@@ -48,6 +55,55 @@ bool IBinding::validateFunctionMapping(const QMetaObject &metaObject) const {
 
     return true;
 }
+
+
+bool
+IBinding::isAdminOnly() const {
+    return _adminOnly;
+}
+
+void
+IBinding::setAdminOnly(const bool adminOnly) {
+    _adminOnly = adminOnly;
+}
+
+bool
+IBinding::ignoreAdmin() {
+    return _ignoreAdmin;
+}
+
+void
+IBinding::setIgnoreAdmin(bool ignoreAdmin) {
+    _ignoreAdmin = ignoreAdmin;
+}
+
+bool
+IBinding::isValidParam(const QString &param) const {
+    if (param.isEmpty()) {
+        _logger->warning(QString("Script parameters can not be empty."));
+
+        return false;
+    }
+
+    if (param.simplified().contains(" ")) {
+        _logger->warning(QString("Script parameters can not have any whitespace characters: %1").arg(param));
+
+        return false;
+    }
+
+    bool isNumber = false;
+
+    param.toDouble(&isNumber);
+
+    if (isNumber) {
+        _logger->warning(QString("Script parameters must not be only numeric values: %1").arg(param));
+
+        return false;
+    }
+
+    return true;
+}
+
 
 IBotJob::FunctionMapping
 IBinding::getFunctionMapping() const {

--- a/bot/botjob/ibinding.h
+++ b/bot/botjob/ibinding.h
@@ -37,18 +37,26 @@ public:
     static const QString BINDING_TYPE_TIMED;
     static const QString FUNCTION;
     static const QString DESCRIPTION;
+    static const QString IGNORE_ADMIN;
 
     bool validateFunctionMapping(const QMetaObject &metaObject) const;
     IBotJob::FunctionMapping getFunctionMapping() const;
     QString getDescription() const;
     void setDescription(const QString &description);
     void setFunctionMapping(const IBotJob::FunctionMapping &functionMapping);
+    bool ignoreAdmin();
+    void setIgnoreAdmin(bool ignoreAdmin);
+    void setAdminOnly(const bool adminOnly);
+    bool isAdminOnly() const;
 
     virtual bool isValid(const QMetaObject &metaObject) const = 0;
 
     Q_PROPERTY(QJsonValue description READ getDescription WRITE setDescription)
 protected:
+    bool isValidParam(const QString &param) const;
 
+    bool _adminOnly = false;
+    bool _ignoreAdmin = false;
     IBotJob::FunctionMapping _functionMapping;
     Logger *_logger = LogFactory::getLogger();
     QString _description;

--- a/bot/botjob/scriptbuilder.h
+++ b/bot/botjob/scriptbuilder.h
@@ -23,8 +23,9 @@
 
 #include <QObject>
 #include <QVariantMap>
+#include <QDir>
+#include <QFile>
 
-#include "bot.h"
 #include "commandbinding.h"
 #include "eventhandler.h"
 #include "gatewaybinding.h"
@@ -33,8 +34,6 @@
 #include "botjob/botscript.h"
 #include "entity/guildentity.h"
 
-class Bot;
-class EventHandler;
 
 class ScriptBuilder : public QObject
 {
@@ -44,10 +43,9 @@ class ScriptBuilder : public QObject
     Logger *_logger;
 
     DatabaseContext _defaultDatabaseContext;
-    QString _fileName;
-    QString _guildId;
     QString _scriptDir;
     QStringList _coreCommandNames;
+    QList<QFileInfo> _validScripts;
     QList<QSharedPointer<IBotJob> > _registeredScripts;
     QList<CommandBinding> _commandBindings;
     QList<GatewayBinding> _gatewayBindings;
@@ -56,26 +54,32 @@ class ScriptBuilder : public QObject
     QMap<QString, QMap<QString, QString> > _functionNameByEventNameByScriptName;
 
     bool isBotScript(const QString &fileName);
-    bool validateScriptCommandName(const QString &command);
-    void loadCoreCommands();
+    void validateScripts();
+    bool validateScriptCommandName(const QString &command, const QString &fileName);
+    void loadCoreCommands(const QString &guildId);
     void addQmlFactory(QSharedPointer<QQmlEngine> engine);
-    void builldBotScripts(const QString &scriptDir);
-    void buildBotScript(const QString &fileWithPath);
-    void namingConflict(const QString &command);
-    void validateScriptName(QSharedPointer<BotScript> botScript);
+    void buildValidBotScripts(const QString &guildId);
+    void buildBotScript(const QFileInfo &fileInfo, const QString &guildId);
+    void namingConflict(const QString &command, const QString &fileName);
+    bool validateScriptName(const QString &scriptName, const QString &fileName);
     void resgisterScriptCommands(QSharedPointer<BotScript> botScript);
     void registerCommandBinding(QSharedPointer<BotScript> botScript, const QJsonValue &binding);
     void registerGatewayBinding(QSharedPointer<BotScript> botScript, const QJsonValue &binding);
     void registerTimedBinding(QSharedPointer<BotScript> botScript, const QJsonValue &binding);
-    void registerEventBindings(QSharedPointer<BotScript> botScript);
+    void registerEventBindings(QSharedPointer<BotScript> botScript, const QString &guildId);
 
+    void validate(const QFileInfo &fileInfo);
+    bool validateScriptCommands(QSharedPointer<BotScript> botScript, const QFileInfo &fileInfo);
+    bool validateCommandBinding(QSharedPointer<BotScript> botScript, const QJsonValue &binding, const QFileInfo &fileInfo);
+    bool validateGatewayBinding(QSharedPointer<BotScript> botScript, const QJsonValue &binding, const QFileInfo &fileInfo);
+    bool validateTimedBinding(QSharedPointer<BotScript> botScript, const QJsonValue &binding, const QString &guildId);
 public:
     ScriptBuilder(EventHandler *eventHandler);
 
     void init(const QString &botToken, const QString &scriptDir);
 
 public slots:
-    void buildScripts(QSharedPointer<GuildEntity> guild);
+    void buildScripts(QSharedPointer<GuildEntity> guild, bool validate);
 
 signals:
     void guildReady(QSharedPointer<GuildEntity> guild);

--- a/bot/entity/commandrestrictions.h
+++ b/bot/entity/commandrestrictions.h
@@ -52,15 +52,15 @@ public:
         }
     }
 
-    inline QString getGuildId() const {
+    QString getGuildId() const {
         return _guildId;
     }
 
-    inline QString getTargetId() const {
+    QString getTargetId() const {
         return _targetId;
     }
 
-    inline QMap<QString, RestrictionState> getRestrictions() const {
+    QMap<QString, RestrictionState> getRestrictions() const {
         return _restrictions;
     }
 

--- a/bot/entity/gridfsfile.h
+++ b/bot/entity/gridfsfile.h
@@ -16,19 +16,11 @@ public:
     static const QString FILENAME;
     static const QString METADATA;
 
-    GridFSFile() {}
-    GridFSFile(const QByteArray &json) : JsonSerializable(json) {}
-    GridFSFile(const QJsonObject &json) : JsonSerializable(json) {}
-    GridFSFile(const QString &json) : JsonSerializable(json) {}
-    GridFSFile operator=(const GridFSFile &other) {
-        if (this == &other) {
-            return *this;
-        }
-
-        _jsonObject = other._jsonObject;
-
-        return *this;
-    }
+    GridFSFile(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    GridFSFile(const GridFSFile &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    GridFSFile(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GridFSFile(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GridFSFile(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getObjectId() const;
     QJsonValue getLength() const;

--- a/bot/entity/guildentity.h
+++ b/bot/entity/guildentity.h
@@ -48,16 +48,17 @@ class GuildEntity : public QObject
     QList<QSharedPointer<IBotJob> > _registeredScripts;
     QList<TimedBinding> _timedBindings;
     QMap<QString, Role> _rolesByRoleId;
-    QMap<QString, QList<GatewayBinding> > _gatewayBindings;
+    QMap<QString, QList<GatewayBinding> > _gatewayBindingsByEventName;
     QMap<QString, CommandBinding> _commandBindings;
     QMap<QString, QMap<QString, CommandRestrictions::RestrictionState> > _mappedStateIdsByCommand;
     QMap<QString, QStringList> _commandNamesByScriptName;
     QString _id = DEFAULT_GUILD_ID;
     QStringList _adminRoleIds;
+    QMap<QString, GatewayBinding> _gatewayBindingsByBindingName;
 
     bool canInvoke(QSharedPointer<EventContext> context, const QString &command);
     Job* getCommandJob(QSharedPointer<EventContext> context);
-    QList<Job*> getGatewayEventJobs(QSharedPointer<EventContext> context) const;
+    QList<Job*> getGatewayEventJobs(QSharedPointer<EventContext> context);
     QString parseCommandToken(const QString &content) const;
     void clearCommand(const QString &commandName, const QString &targetId);
 

--- a/bot/entity/guildentity.h
+++ b/bot/entity/guildentity.h
@@ -62,6 +62,10 @@ class GuildEntity : public QObject
     QString parseCommandToken(const QString &content) const;
     void clearCommand(const QString &commandName, const QString &targetId);
 
+    void updateState(QMap<QString, CommandRestrictions::RestrictionState> &restrictionUpdates,
+                     const QString &name,
+                     const QString &targetId,
+                     CommandRestrictions::RestrictionState state);
 public:
     GuildEntity() {}
     GuildEntity(const Guild &guild);
@@ -69,6 +73,7 @@ public:
     static const QString DEFAULT_GUILD_ID;
     static const QString GUILD_RESTRICTIONS;
     static const QString RESTRICTIONS;
+    static const QString GUILD_ID_ALIAS;
 
     void initRestrictionStates(const QJsonObject &json);
     bool hasAdminRole(QSharedPointer<EventContext> context);
@@ -86,15 +91,12 @@ public:
     void setTimedBindings(const QList<TimedBinding> &timedBindings);
     void updateRole(const Role &role);
     void removeRole(const QString &roleId);
-    void removeRestrictionState(const QString &commandName, const QString &targetId);
-    void removeRestrictionStatesForCommand(const QString &commandName);
-    void removeRestrictionsById(const QString &targetId);
     void removeAllRestrictionStates();
-    void updateRestrictionState(const QString &commandName,
+    void updateAllRestrictionStates(const QString &targetId,
+                                            CommandRestrictions::RestrictionState state);
+    void updateRestrictionStates(const QString &commandName,
                        const QString &targetId,
                        CommandRestrictions::RestrictionState state);
-    void updateAllRestrictionStates(const QString &targetId,
-                                    CommandRestrictions::RestrictionState state);
 
     static void setAdminRoleName(const QString &roleName);
     static void setBotOwnerId(const QString &userId);
@@ -103,7 +105,6 @@ public:
 
 signals:
     void restrictionsUpdate(QSharedPointer<CommandRestrictions> restrictions);
-    void restrictionsRemoval(QSharedPointer<CommandRestrictions> restrictions);
 };
 
 #endif // GUILDENTITY_H

--- a/bot/entity/idbmanager.h
+++ b/bot/entity/idbmanager.h
@@ -26,7 +26,6 @@ public:
     virtual void initGuild(QSharedPointer<GuildEntity> payload) = 0;
     virtual void init() = 0;
     virtual void restrictionsUpdate(QSharedPointer<CommandRestrictions> restrictions) = 0;
-    virtual void restrictionsRemoval(QSharedPointer<CommandRestrictions> restrictions) = 0;
     virtual void saveEvent(QSharedPointer<GatewayPayload> payload) = 0;
 };
 

--- a/bot/entity/mongomanager.cpp
+++ b/bot/entity/mongomanager.cpp
@@ -98,17 +98,16 @@ MongoManager::saveEvent(QSharedPointer<GatewayPayload> payload) {
 }
 
 void
-MongoManager::restrictionsRemoval(QSharedPointer<CommandRestrictions> restrictions) {
-    setCollection(GuildEntity::GUILD_RESTRICTIONS);
-
-    updateRestrictions(restrictions, UNSET_OPERATION);
-}
-
-void
 MongoManager::restrictionsUpdate(QSharedPointer<CommandRestrictions> restrictions) {
     setCollection(GuildEntity::GUILD_RESTRICTIONS);
 
-    updateRestrictions(restrictions, SET_OPERATION);
+    if (restrictions->getRestrictions().isEmpty() ||
+            restrictions->getRestrictions().first() == CommandRestrictions::REMOVED) {
+
+        updateRestrictions(restrictions, UNSET_OPERATION);
+    } else {
+        updateRestrictions(restrictions, SET_OPERATION);
+    }
 }
 
 void
@@ -131,12 +130,12 @@ MongoManager::updateRestrictions(QSharedPointer<CommandRestrictions> restriction
         while (m_it.hasNext()) {
             m_it.next();
 
-            update << QString("%1.%2%3")
-                        .arg(GuildEntity::RESTRICTIONS)
-                        .arg(m_it.key())
-                        .arg(targetId)
-                        .toStdString()
-                  << m_it.value();
+            QString updateStr = QString("%1.%2%3")
+                    .arg(GuildEntity::RESTRICTIONS)
+                    .arg(m_it.key())
+                    .arg(targetId);
+
+            update << updateStr.toStdString() << m_it.value();
         }
     } else {
         update << GuildEntity::RESTRICTIONS.toStdString() << "";

--- a/bot/entity/mongomanager.h
+++ b/bot/entity/mongomanager.h
@@ -72,7 +72,6 @@ public:
     void initGuild(QSharedPointer<GuildEntity> guildEntity) override;
     void init() override;
     void restrictionsUpdate(QSharedPointer<CommandRestrictions> restrictions) override;
-    void restrictionsRemoval(QSharedPointer<CommandRestrictions> restrictions) override;
     void saveEvent(QSharedPointer<GatewayPayload> payload) override;
 
 private slots:

--- a/bot/entity/sqlmanager.cpp
+++ b/bot/entity/sqlmanager.cpp
@@ -137,18 +137,6 @@ SqlManager::restrictionsUpdate(QSharedPointer<CommandRestrictions> restrictions)
     }
 }
 
-void
-SqlManager::restrictionsRemoval(QSharedPointer<CommandRestrictions> restrictions) {
-    if (!isDbOpen()) {
-        return;
-    }
-
-    if (restrictions->getTargetId().isEmpty()) {
-        clearCommand(restrictions);
-    } else {
-        clearCommandForId(restrictions);
-    }
-}
 
 void
 SqlManager::clearCommand(QSharedPointer<CommandRestrictions> restrictions) {

--- a/bot/entity/sqlmanager.h
+++ b/bot/entity/sqlmanager.h
@@ -63,7 +63,6 @@ public:
     void initGuild(QSharedPointer<GuildEntity> payload) override;
     void init() override;
     void restrictionsUpdate(QSharedPointer<CommandRestrictions> restrictions) override;
-    void restrictionsRemoval(QSharedPointer<CommandRestrictions> restrictions) override;
     void saveEvent(QSharedPointer<GatewayPayload> payload) override {
         Q_UNUSED(payload)
 

--- a/bot/entitymanager.cpp
+++ b/bot/entitymanager.cpp
@@ -50,8 +50,6 @@ EntityManager::initGuildFromPayload(QSharedPointer<GatewayPayload> payload) {
 
     guildEntity->setId(guild.getId().toString());
 
-    QObject::connect(guildEntity.data(), &GuildEntity::restrictionsRemoval, this, &EntityManager::restrictionsRemoval);
-
     QObject::connect(guildEntity.data(), &GuildEntity::restrictionsUpdate, this, &EntityManager::restrictionsUpdate);
 
     initGuild(guildEntity);
@@ -79,11 +77,6 @@ EntityManager::init() {
 void
 EntityManager::restrictionsUpdate(QSharedPointer<CommandRestrictions> restrictions) {
     _manager->restrictionsUpdate(restrictions);
-}
-
-void
-EntityManager::restrictionsRemoval(QSharedPointer<CommandRestrictions> restrictions) {
-    _manager->restrictionsRemoval(restrictions);
 }
 
 void

--- a/bot/entitymanager.cpp
+++ b/bot/entitymanager.cpp
@@ -100,7 +100,7 @@ void
 EntityManager::initGuild(QSharedPointer<GuildEntity> guildEntity) {
     _manager->initGuild(guildEntity);
 
-    emit guildInitialized(guildEntity);
+    emit guildInitialized(guildEntity, false);
 }
 
 void

--- a/bot/entitymanager.h
+++ b/bot/entitymanager.h
@@ -53,7 +53,6 @@ public slots:
     void initGuildFromPayload(QSharedPointer<GatewayPayload> payload);
     void init();
     void restrictionsUpdate(QSharedPointer<CommandRestrictions> restrictions);
-    void restrictionsRemoval(QSharedPointer<CommandRestrictions> restrictions);
     void saveEvent(QSharedPointer<GatewayPayload> payload);
 };
 

--- a/bot/entitymanager.h
+++ b/bot/entitymanager.h
@@ -46,7 +46,7 @@ public:
     EntityManager();
 
 signals:
-    void guildInitialized(QSharedPointer<GuildEntity> guildEntity);
+    void guildInitialized(QSharedPointer<GuildEntity> guildEntity, bool validate);
 
 public slots:
     void initGuild(QSharedPointer<GuildEntity> payload);

--- a/bot/eventhandler.cpp
+++ b/bot/eventhandler.cpp
@@ -30,6 +30,7 @@
 
 const int EventHandler::JOB_POLL_MS = 500;
 
+
 EventHandler::EventHandler() {
     GuildEntity::setBotOwnerId(Settings::ownerId());
 
@@ -306,7 +307,7 @@ EventHandler::updateRestrictionState(const EventContext &context, CommandRestric
 
         QString targetId = context.getArgs()[2].toString();
 
-        _availableGuilds[guildId]->updateRestrictionState(commandName, targetId, state);
+        _availableGuilds[guildId]->updateRestrictionStates(commandName, targetId, state);
     } else {
         _logger->debug(QString("\"%1\" requires a scriptName/commandName and user/role/channel/guild id...").arg(context.getContent().toString()));
     }
@@ -322,10 +323,10 @@ EventHandler::updateAllRestrictionStates(const EventContext &context, CommandRes
         if (context.getArgs().size() > 1) {
             targetId = context.getArgs()[1].toString();
         } else {
-            targetId = guildId;
+            targetId = GuildEntity::GUILD_ID_ALIAS;
         }
 
-         _availableGuilds[guildId]->updateAllRestrictionStates(targetId, state);
+         _availableGuilds[guildId]->updateRestrictionStates(QString(), targetId, state);
     }
 }
 
@@ -338,7 +339,7 @@ EventHandler::removeRestrictionState(const EventContext &context) {
 
         QString targetId = context.getArgs()[2].toString();
 
-        _availableGuilds[guildId]->removeRestrictionState(commandName, targetId);
+        _availableGuilds[guildId]->updateRestrictionStates(commandName, targetId, CommandRestrictions::REMOVED);
     } else {
         _logger->debug(QString("\"%1\" requires a scriptName/commandName and target id...").arg(context.getContent().toString()));
     }
@@ -350,31 +351,5 @@ EventHandler::removeAllRestrictionStates(const EventContext &context) {
 
     if (isGuildReady(guildId)) {
          _availableGuilds[guildId]->removeAllRestrictionStates();
-    }
-}
-
-void
-EventHandler::removeRestrictionStatesForCommand(const EventContext &context) {
-    QString guildId = context.getGuildId().toString();
-
-    if (isGuildReady(guildId) && context.getArgs().size() > 1) {
-        QString commandName = context.getArgs()[1].toString();
-
-         _availableGuilds[guildId]->removeRestrictionState(commandName, QString());
-    } else {
-        _logger->debug(QString("\"%1\" requires a scriptName/commandName...").arg(context.getContent().toString()));
-    }
-}
-
-void
-EventHandler::removeRestrictionStatesForId(const EventContext &context) {
-    QString guildId = context.getGuildId().toString();
-
-    if (isGuildReady(guildId) && context.getArgs().size() > 1) {
-        QString targetId = context.getArgs()[1].toString();
-
-         _availableGuilds[guildId]->removeRestrictionState(QString(), targetId);
-    } else {
-        _logger->debug(QString("\"%1\" requires a targetId...").arg(context.getContent().toString()));
     }
 }

--- a/bot/eventhandler.cpp
+++ b/bot/eventhandler.cpp
@@ -147,12 +147,18 @@ EventHandler::reloadGuild(const EventContext &context) {
 
             _jobQueueTimer->stop();
 
+            bool validate = true;
+
             for (auto guild : _availableGuilds.values()) {
                 _timedJobs.clear(guild->getId());
 
                 _jobQueue.clear(guild->getId());
 
-                emit reloadScripts(guild);
+                emit reloadScripts(guild, validate);
+
+                if (validate) {
+                    validate = false; // only validate once.
+                }
             }
         } else {
             _logger->warning(QString("User %1 attempted to .reload all guilds but they are not Bot Owner...").arg(userId));
@@ -162,7 +168,7 @@ EventHandler::reloadGuild(const EventContext &context) {
 
         _jobQueue.clear(guildId);
 
-        emit reloadScripts(_availableGuilds[guildId]);
+        emit reloadScripts(_availableGuilds[guildId], true);
     }
 }
 

--- a/bot/eventhandler.h
+++ b/bot/eventhandler.h
@@ -67,8 +67,7 @@ public:
 public slots:
     void removeRestrictionState(const EventContext &context);
     void removeAllRestrictionStates(const EventContext &context);
-    void removeRestrictionStatesForCommand(const EventContext &context);
-    void removeRestrictionStatesForId(const EventContext &context);
+
     void updateRestrictionState(const EventContext &context, CommandRestrictions::RestrictionState state);
     void updateAllRestrictionStates(const EventContext &context, CommandRestrictions::RestrictionState state);
     void displayTimedJobs(EventContext context);

--- a/bot/eventhandler.h
+++ b/bot/eventhandler.h
@@ -31,7 +31,6 @@
 #include "payloads/gatewaypayload.h"
 #include "payloads/message.h"
 #include "payloads/guild.h"
-#include "botjob/scriptbuilder.h"
 #include "botjob/corecommand.h"
 #include "util/settings.h"
 #include "logging/logfactory.h"
@@ -60,7 +59,7 @@ class EventHandler : public QObject
     void processMessageUpdate(QSharedPointer<EventContext> context);
 
 signals:
-    void reloadScripts(QSharedPointer<GuildEntity> guild);
+    void reloadScripts(QSharedPointer<GuildEntity> guild, bool validate);
 
 public:
     EventHandler();

--- a/bot/payloads/activity.h
+++ b/bot/payloads/activity.h
@@ -52,10 +52,11 @@ public:
     static const QString INSTANCE;
     static const QString FLAGS;
 
-    Activity() {}
-    Activity(const QByteArray &json) : JsonSerializable(json) {}
-    Activity(const QJsonObject &json) : JsonSerializable(json) {}
-    Activity(const QString &json) : JsonSerializable(json) {}
+    Activity(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Activity(const Activity &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Activity(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Activity(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Activity(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonObject getAssets() const;
     QJsonObject getEmoji() const;

--- a/bot/payloads/activityassets.cpp
+++ b/bot/payloads/activityassets.cpp
@@ -26,7 +26,7 @@ const QString ActivityAssets::SMALL_IMAGE = "small_image";
 const QString ActivityAssets::SMALL_TEXT = "small_text";
 
 QJsonValue
-ActivityAssets::getLargeText() {
+ActivityAssets::getLargeText() const {
     return _jsonObject[LARGE_TEXT].toString();
 }
 
@@ -36,7 +36,7 @@ ActivityAssets::setLargeText(const QJsonValue &largeText) {
 }
 
 QJsonValue
-ActivityAssets::getSmallImage() {
+ActivityAssets::getSmallImage() const {
     return _jsonObject[SMALL_IMAGE].toString();
 }
 
@@ -46,7 +46,7 @@ ActivityAssets::setSmallImage(const QJsonValue &smallImage) {
 }
 
 QJsonValue
-ActivityAssets::getSmallText() {
+ActivityAssets::getSmallText() const {
     return _jsonObject[SMALL_TEXT].toString();
 }
 
@@ -56,7 +56,7 @@ ActivityAssets::setSmallText(const QJsonValue &smallText) {
 }
 
 QJsonValue
-ActivityAssets::getLargeImage() {
+ActivityAssets::getLargeImage() const {
     return _jsonObject[LARGE_IMAGE].toString();
 }
 

--- a/bot/payloads/activityassets.h
+++ b/bot/payloads/activityassets.h
@@ -34,15 +34,16 @@ public:
     static const QString SMALL_IMAGE;
     static const QString SMALL_TEXT;
 
-    ActivityAssets() {}
-    ActivityAssets(const QByteArray &json) : JsonSerializable(json) {}
-    ActivityAssets(const QJsonObject &json) : JsonSerializable(json) {}
-    ActivityAssets(const QString &json) : JsonSerializable(json) {}
+    ActivityAssets(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    ActivityAssets(const ActivityAssets &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    ActivityAssets(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivityAssets(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivityAssets(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
-    QJsonValue getLargeText();
-    QJsonValue getSmallImage();
-    QJsonValue getSmallText();
-    QJsonValue getLargeImage();
+    QJsonValue getLargeText() const;
+    QJsonValue getSmallImage() const;
+    QJsonValue getSmallText() const;
+    QJsonValue getLargeImage() const;
     void setLargeImage(const QJsonValue &largeImage);
     void setLargeText(const QJsonValue &largeText);
     void setSmallImage(const QJsonValue &smallImage);

--- a/bot/payloads/activityemoji.h
+++ b/bot/payloads/activityemoji.h
@@ -33,10 +33,11 @@ public:
     static const QString ID;
     static const QString ANIMATED;
 
-    ActivityEmoji() {}
-    ActivityEmoji(const QByteArray &json) : JsonSerializable(json) {}
-    ActivityEmoji(const QJsonObject &json) : JsonSerializable(json) {}
-    ActivityEmoji(const QString &json) : JsonSerializable(json) {}
+    ActivityEmoji(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    ActivityEmoji(const ActivityEmoji &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    ActivityEmoji(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivityEmoji(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivityEmoji(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getAnimated() const;
     QJsonValue getId() const;

--- a/bot/payloads/activityparty.h
+++ b/bot/payloads/activityparty.h
@@ -32,10 +32,11 @@ public:
     static const QString ID;
     static const QString SIZE;
 
-    ActivityParty() {}
-    ActivityParty(const QByteArray &json) : JsonSerializable(json) {}
-    ActivityParty(const QJsonObject &json) : JsonSerializable(json) {}
-    ActivityParty(const QString &json) : JsonSerializable(json) {}
+    ActivityParty(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    ActivityParty(const ActivityParty &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    ActivityParty(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json) {}
+    ActivityParty(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json) {}
+    ActivityParty(const QString &json, QObject *parent = nullptr) : JsonSerializable(json) {}
 
     QJsonArray getSize() const;
     QJsonValue getId() const;

--- a/bot/payloads/activityparty.h
+++ b/bot/payloads/activityparty.h
@@ -34,9 +34,9 @@ public:
 
     ActivityParty(QObject *parent = nullptr) : JsonSerializable(parent) {}
     ActivityParty(const ActivityParty &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
-    ActivityParty(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json) {}
-    ActivityParty(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json) {}
-    ActivityParty(const QString &json, QObject *parent = nullptr) : JsonSerializable(json) {}
+    ActivityParty(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivityParty(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivityParty(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonArray getSize() const;
     QJsonValue getId() const;

--- a/bot/payloads/activitysecrets.cpp
+++ b/bot/payloads/activitysecrets.cpp
@@ -25,7 +25,7 @@ const QString ActivitySecrets::MATCH = "match";
 const QString ActivitySecrets::SPECTATE = "spectate";
 
 QJsonValue
-ActivitySecrets::getJoin() {
+ActivitySecrets::getJoin() const {
     return _jsonObject[JOIN].toString();
 }
 
@@ -35,7 +35,7 @@ ActivitySecrets::setJoin(const QJsonValue &join) {
 }
 
 QJsonValue
-ActivitySecrets::getSpectate() {
+ActivitySecrets::getSpectate() const {
     return _jsonObject[SPECTATE].toString();
 }
 
@@ -45,7 +45,7 @@ ActivitySecrets::setSpectate(const QJsonValue &spectate) {
 }
 
 QJsonValue
-ActivitySecrets::getMatch() {
+ActivitySecrets::getMatch() const {
     return _jsonObject[MATCH].toString();
 }
 

--- a/bot/payloads/activitysecrets.h
+++ b/bot/payloads/activitysecrets.h
@@ -33,14 +33,15 @@ public:
     static const QString MATCH;
     static const QString SPECTATE;
 
-    ActivitySecrets() {}
-    ActivitySecrets(const QByteArray &json) : JsonSerializable(json) {}
-    ActivitySecrets(const QJsonObject &json) : JsonSerializable(json) {}
-    ActivitySecrets(const QString &json) : JsonSerializable(json) {}
+    ActivitySecrets(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    ActivitySecrets(const ActivitySecrets &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    ActivitySecrets(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivitySecrets(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivitySecrets(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
-    QJsonValue getJoin();
-    QJsonValue getMatch();
-    QJsonValue getSpectate();
+    QJsonValue getJoin() const;
+    QJsonValue getMatch() const;
+    QJsonValue getSpectate() const;
     void setJoin(const QJsonValue &join);
     void setMatch(const QJsonValue &match);
     void setSpectate(const QJsonValue &spectate);

--- a/bot/payloads/activitytimestamps.h
+++ b/bot/payloads/activitytimestamps.h
@@ -32,10 +32,11 @@ public:
     static const QString START;
     static const QString END;
 
-    ActivityTimestamps() {}
-    ActivityTimestamps(const QByteArray &json) : JsonSerializable(json) {}
-    ActivityTimestamps(const QJsonObject &json) : JsonSerializable(json) {}
-    ActivityTimestamps(const QString &json) : JsonSerializable(json) {}
+    ActivityTimestamps(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    ActivityTimestamps(const ActivityTimestamps &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    ActivityTimestamps(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivityTimestamps(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ActivityTimestamps(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     void setEnd(const QJsonValue &end);
     void setStart(const QJsonValue &start);

--- a/bot/payloads/attachment.h
+++ b/bot/payloads/attachment.h
@@ -44,27 +44,11 @@ public:
     static const QString CHANNEL_ID;
     static const QString GUILD_ID;
 
-    Attachment() {}
-    Attachment(const QByteArray &json) : JsonSerializable(json) {}
-    Attachment(const QJsonObject &json) : JsonSerializable(json) {}
-    Attachment(const QString &json) : JsonSerializable(json) {}
-    Attachment(const Attachment &other) {
-        if (this == &other) {
-            return;
-        }
-
-        _jsonObject = other._jsonObject;
-    }
-
-    Attachment operator=(const Attachment &other) {
-        if (this == &other) {
-            return *this;
-        }
-
-        _jsonObject = other._jsonObject;
-
-        return *this;
-    }
+    Attachment(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Attachment(const Attachment &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Attachment(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Attachment(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Attachment(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getDescription() const;
     QJsonValue getContentType() const;

--- a/bot/payloads/attachment.h
+++ b/bot/payloads/attachment.h
@@ -48,6 +48,14 @@ public:
     Attachment(const QByteArray &json) : JsonSerializable(json) {}
     Attachment(const QJsonObject &json) : JsonSerializable(json) {}
     Attachment(const QString &json) : JsonSerializable(json) {}
+    Attachment(const Attachment &other) {
+        if (this == &other) {
+            return;
+        }
+
+        _jsonObject = other._jsonObject;
+    }
+
     Attachment operator=(const Attachment &other) {
         if (this == &other) {
             return *this;

--- a/bot/payloads/attachment.h
+++ b/bot/payloads/attachment.h
@@ -49,6 +49,15 @@ public:
     Attachment(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
     Attachment(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
     Attachment(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Attachment& operator=(const Attachment &other) {
+        if (this == &other) {
+            return *this;
+        }
+
+        _jsonObject = other._jsonObject;
+
+        return *this;
+    }
 
     QJsonValue getDescription() const;
     QJsonValue getContentType() const;

--- a/bot/payloads/channel.cpp
+++ b/bot/payloads/channel.cpp
@@ -40,7 +40,7 @@ const QString Channel::PARENT_ID = "parent_id";
 const QString Channel::LAST_PIN_TIMESTAMP = "last_pin_timestamp";
 
 QJsonValue
-Channel::getId() {
+Channel::getId() const {
     return _jsonObject[ID];
 }
 
@@ -50,7 +50,7 @@ Channel::setId(const QJsonValue &id) {
 }
 
 QJsonValue
-Channel::getType() {
+Channel::getType() const {
     return _jsonObject[TYPE];
 }
 
@@ -60,7 +60,7 @@ Channel::setType(const QJsonValue &type) {
 }
 
 QJsonValue
-Channel::getGuildId() {
+Channel::getGuildId() const {
     return _jsonObject[GUILD_ID];
 }
 
@@ -70,7 +70,7 @@ Channel::setGuildId(const QJsonValue &guildId) {
 }
 
 QJsonValue
-Channel::getPosition() {
+Channel::getPosition() const {
     return _jsonObject[POSITION];
 }
 
@@ -80,7 +80,7 @@ Channel::setPosition(const QJsonValue &position) {
 }
 
 QJsonArray
-Channel::getPermissionOverwrites() {
+Channel::getPermissionOverwrites() const {
     return _jsonObject[PERMISSION_OVERWRITES].toArray();
 }
 
@@ -90,7 +90,7 @@ Channel::setPermissionOverwrites(const QJsonArray &permissionOverwrites) {
 }
 
 QJsonValue
-Channel::getName() {
+Channel::getName() const {
    return _jsonObject[NAME];
 }
 
@@ -100,7 +100,7 @@ Channel::setName(const QJsonValue &name) {
 }
 
 QJsonValue
-Channel::getTopic() {
+Channel::getTopic() const {
     return _jsonObject[TOPIC];
 }
 
@@ -110,7 +110,7 @@ Channel::setTopic(const QJsonValue &topic) {
 }
 
 QJsonValue
-Channel::getNsfw() {
+Channel::getNsfw() const {
     return _jsonObject[NSFW];
 }
 
@@ -120,7 +120,7 @@ Channel::setNsfw(const QJsonValue &nsfw) {
 }
 
 QJsonValue
-Channel::getLastMessageId() {
+Channel::getLastMessageId() const {
     return _jsonObject[LAST_MESSAGE_ID];
 }
 
@@ -130,7 +130,7 @@ Channel::setLastMessageId(const QJsonValue &last_message_id) {
 }
 
 QJsonValue
-Channel::getBitrate() {
+Channel::getBitrate() const {
     return _jsonObject[BITRATE];
 }
 
@@ -140,7 +140,7 @@ Channel::setBitrate(const QJsonValue &bitrate) {
 }
 
 QJsonValue
-Channel::getUserLimit() {
+Channel::getUserLimit() const {
     return _jsonObject[USER_LIMIT];
 }
 
@@ -150,7 +150,7 @@ Channel::setUserLimit(const QJsonValue &userLimit) {
 }
 
 QJsonValue
-Channel::getRateLimitPerUser() {
+Channel::getRateLimitPerUser() const {
     return _jsonObject[RATE_LIMIT_PER_USER];
 }
 
@@ -160,7 +160,7 @@ Channel::setRateLimitPerUser(const QJsonValue &rateLimitPerUser) {
 }
 
 QJsonArray
-Channel::getRecipients() {
+Channel::getRecipients() const {
     return _jsonObject[RECIPIENTS].toArray();
 }
 
@@ -170,7 +170,7 @@ Channel::setRecipients(const QJsonArray &recipients) {
 }
 
 QJsonValue
-Channel::getIcon() {
+Channel::getIcon() const {
     return _jsonObject[ICON];
 }
 
@@ -180,7 +180,7 @@ Channel::setIcon(const QJsonValue &icon) {
 }
 
 QJsonValue
-Channel::getOwnerId() {
+Channel::getOwnerId() const {
     return _jsonObject[OWNER_ID];
 }
 
@@ -190,7 +190,7 @@ Channel::setOwnerId(const QJsonValue &ownerId) {
 }
 
 QJsonValue
-Channel::getApplicationId() {
+Channel::getApplicationId() const {
     return _jsonObject[APPLICATION_ID];
 }
 
@@ -200,7 +200,7 @@ Channel::setApplicationId(const QJsonValue &applicationId) {
 }
 
 QJsonValue
-Channel::getParentId() {
+Channel::getParentId() const {
     return _jsonObject[PARENT_ID];
 }
 
@@ -210,7 +210,7 @@ Channel::setParentId(const QJsonValue &parentId) {
 }
 
 QJsonValue
-Channel::getLastPinTimestamp() {
+Channel::getLastPinTimestamp() const {
     return _jsonObject[LAST_PIN_TIMESTAMP];
 }
 

--- a/bot/payloads/channel.h
+++ b/bot/payloads/channel.h
@@ -48,29 +48,30 @@ public:
     static const QString PARENT_ID;
     static const QString LAST_PIN_TIMESTAMP;
 
-    Channel() {}
-    Channel(const QByteArray &json) : JsonSerializable(json) {}
-    Channel(const QJsonObject &json) : JsonSerializable(json) {}
-    Channel(const QString &json) : JsonSerializable(json) {}
+    Channel(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Channel(const Channel &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Channel(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Channel(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Channel(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
-    QJsonValue getApplicationId();
-    QJsonValue getBitrate();
-    QJsonValue getGuildId();
-    QJsonValue getIcon();
-    QJsonValue getId();
-    QJsonValue getLastMessageId();
-    QJsonValue getLastPinTimestamp();
-    QJsonValue getOwnerId();
-    QJsonValue getName();
-    QJsonValue getNsfw();
-    QJsonValue getParentId();
-    QJsonValue getPosition();
-    QJsonValue getRateLimitPerUser();
-    QJsonValue getTopic();
-    QJsonValue getType();
-    QJsonValue getUserLimit();
-    QJsonArray getRecipients();
-    QJsonArray getPermissionOverwrites();
+    QJsonValue getApplicationId() const;
+    QJsonValue getBitrate() const;
+    QJsonValue getGuildId() const;
+    QJsonValue getIcon() const;
+    QJsonValue getId() const;
+    QJsonValue getLastMessageId() const;
+    QJsonValue getLastPinTimestamp() const;
+    QJsonValue getOwnerId() const;
+    QJsonValue getName() const;
+    QJsonValue getNsfw() const;
+    QJsonValue getParentId() const;
+    QJsonValue getPosition() const;
+    QJsonValue getRateLimitPerUser() const;
+    QJsonValue getTopic() const;
+    QJsonValue getType() const;
+    QJsonValue getUserLimit() const;
+    QJsonArray getRecipients() const;
+    QJsonArray getPermissionOverwrites() const;
     void setId(const QJsonValue &id);
     void setType(const QJsonValue &type);
     void setGuildId(const QJsonValue &guildId);

--- a/bot/payloads/channelmention.h
+++ b/bot/payloads/channelmention.h
@@ -35,10 +35,11 @@ public:
     static const QString TYPE;
     static const QString NAME;
 
-    ChannelMention() {}
-    ChannelMention(const QByteArray &json) : JsonSerializable(json) {}
-    ChannelMention(const QJsonObject &json) : JsonSerializable(json) {}
-    ChannelMention(const QString &json) : JsonSerializable(json) {}
+    ChannelMention(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    ChannelMention(const ChannelMention &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    ChannelMention(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ChannelMention(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ChannelMention(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getGuildId() const;
     QJsonValue getId() const;

--- a/bot/payloads/clientstatus.h
+++ b/bot/payloads/clientstatus.h
@@ -33,10 +33,11 @@ public:
     static const QString MOBILE;
     static const QString WEB;
 
-    ClientStatus() {}
-    ClientStatus(const QByteArray &json) : JsonSerializable(json) {}
-    ClientStatus(const QJsonObject &json) : JsonSerializable(json) {}
-    ClientStatus(const QString &json) : JsonSerializable(json) {}
+    ClientStatus(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    ClientStatus(const ClientStatus &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    ClientStatus(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ClientStatus(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    ClientStatus(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getDesktop() const;
     QJsonValue getMobile() const;

--- a/bot/payloads/embed.cpp
+++ b/bot/payloads/embed.cpp
@@ -34,7 +34,11 @@ const QString Embed::VIDEO = "video";
 const QString Embed::AUTHOR = "author";
 const QString Embed::FIELDS = "fields";
 
-Embed::Embed(const QString &title, const QString &description, const QString &url, const int color) {
+Embed::Embed(const QString &title,
+             const QString &description,
+             const QString &url,
+             const int color,
+             QObject *parent) :JsonSerializable(parent) {
     _jsonObject[TITLE] = title;
 
     _jsonObject[DESCRIPTION] = description;

--- a/bot/payloads/embed.h
+++ b/bot/payloads/embed.h
@@ -47,11 +47,16 @@ public:
     static const QString AUTHOR;
     static const QString FIELDS;
 
-    Embed() {}
-    Embed(const QString &title, const QString &description, const QString &url, const int color);
-    Embed(const QByteArray &json) : JsonSerializable(json) {}
-    Embed(const QJsonObject &json) : JsonSerializable(json) {}
-    Embed(const QString &json) : JsonSerializable(json) {}
+    Embed(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Embed(const Embed &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Embed(const QString &title,
+          const QString &description,
+          const QString &url,
+          const int color,
+          QObject *parent = nullptr);
+    Embed(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Embed(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Embed(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     Q_INVOKABLE QJsonArray getFields() const;
     Q_INVOKABLE QJsonObject getAuthor() const;

--- a/bot/payloads/embedauthor.cpp
+++ b/bot/payloads/embedauthor.cpp
@@ -26,7 +26,10 @@ const QString EmbedAuthor::PROXY_ICON_URL = "proxy_icon_url";
 const QString EmbedAuthor::URL = "url";
 
 
-EmbedAuthor::EmbedAuthor(const QString &name, const QString &url, const QString &iconUrl) {
+EmbedAuthor::EmbedAuthor(const QString &name,
+                         const QString &url,
+                         const QString &iconUrl,
+                         QObject *parent) : JsonSerializable(parent) {
     _jsonObject[NAME] = name;
 
     _jsonObject[URL] = url;

--- a/bot/payloads/embedauthor.h
+++ b/bot/payloads/embedauthor.h
@@ -34,11 +34,15 @@ public:
     const static QString PROXY_ICON_URL;
     const static QString URL;
 
-    EmbedAuthor() {}
-    EmbedAuthor(const QString &name, const QString &url, const QString &iconUrl);
-    EmbedAuthor(const QByteArray &json) : JsonSerializable(json) {}
-    EmbedAuthor(const QJsonObject &json) : JsonSerializable(json) {}
-    EmbedAuthor(const QString &json) : JsonSerializable(json) {}
+    EmbedAuthor(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    EmbedAuthor(const EmbedAuthor &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    EmbedAuthor(const QString &name,
+                const QString &url,
+                const QString &iconUrl,
+                QObject *parent = nullptr);
+    EmbedAuthor(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    EmbedAuthor(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    EmbedAuthor(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     Q_INVOKABLE QJsonValue getIconUrl() const;
     Q_INVOKABLE QJsonValue getName() const;

--- a/bot/payloads/embedfield.cpp
+++ b/bot/payloads/embedfield.cpp
@@ -24,7 +24,10 @@ const QString EmbedField::INLINE = "inline";
 const QString EmbedField::NAME = "name";
 const QString EmbedField::VALUE = "value";
 
-EmbedField::EmbedField(const QString &name, const QString &value, const bool isInline) {
+EmbedField::EmbedField(const QString &name,
+                       const QString &value,
+                       const bool isInline,
+                       QObject *parent) : JsonSerializable(parent) {
      _jsonObject[NAME] = name;
 
      _jsonObject[VALUE] = value;

--- a/bot/payloads/embedfield.h
+++ b/bot/payloads/embedfield.h
@@ -33,11 +33,15 @@ public:
     static const QString NAME;
     static const QString VALUE;
 
-    EmbedField() {}
-    EmbedField(const QString &name, const QString &value, const bool isInline);
-    EmbedField(const QByteArray &json) : JsonSerializable(json) {}
-    EmbedField(const QJsonObject &json) : JsonSerializable(json) {}
-    EmbedField(const QString &json) : JsonSerializable(json) {}
+    EmbedField(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    EmbedField(const EmbedField &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    EmbedField(const QString &name,
+               const QString &value,
+               const bool isInline,
+               QObject *parent = nullptr);
+    EmbedField(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    EmbedField(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    EmbedField(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     Q_INVOKABLE QJsonValue getInline() const;
     Q_INVOKABLE QJsonValue getName() const;

--- a/bot/payloads/embedfooter.cpp
+++ b/bot/payloads/embedfooter.cpp
@@ -25,7 +25,9 @@ const QString EmbedFooter::ICON_URL = "icon_url";
 const QString EmbedFooter::PROXY_ICON_URL = "proxy_icon_url";
 const QString EmbedFooter::TEXT = "text";
 
-EmbedFooter::EmbedFooter(const QString &text, const QString &iconUrl) {
+EmbedFooter::EmbedFooter(const QString &text,
+                         const QString &iconUrl,
+                         QObject *parent) : JsonSerializable(parent) {
      _jsonObject[TEXT] = text;
 
      _jsonObject[ICON_URL] = iconUrl;

--- a/bot/payloads/embedfooter.h
+++ b/bot/payloads/embedfooter.h
@@ -33,11 +33,12 @@ public:
     static const QString PROXY_ICON_URL;
     static const QString TEXT;
 
-    EmbedFooter() {}
-    EmbedFooter(const QString &text, const QString &iconUrl);
-    EmbedFooter(const QByteArray &json) : JsonSerializable(json) {}
-    EmbedFooter(const QJsonObject &json) : JsonSerializable(json) {}
-    EmbedFooter(const QString &json) : JsonSerializable(json) {}
+    EmbedFooter(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    EmbedFooter(const EmbedFooter &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    EmbedFooter(const QString &text, const QString &iconUrl, QObject *parent = nullptr);
+    EmbedFooter(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    EmbedFooter(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    EmbedFooter(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     Q_INVOKABLE QJsonValue getIconUrl() const;
     Q_INVOKABLE QJsonValue getProxyIconUrl() const;

--- a/bot/payloads/embedmedia.cpp
+++ b/bot/payloads/embedmedia.cpp
@@ -26,7 +26,10 @@ const QString EmbedMedia::PROXY_URL = "proxy_url";
 const QString EmbedMedia::URL = "url";
 const QString EmbedMedia::WIDTH = "width";
 
-EmbedMedia::EmbedMedia(const QString &url, const int height, const int width) {
+EmbedMedia::EmbedMedia(const QString &url,
+                       const int height,
+                       const int width,
+                       QObject *parent) : JsonSerializable(parent) {
     _jsonObject[URL] = url;
 
     if (height > 0) {

--- a/bot/payloads/embedmedia.h
+++ b/bot/payloads/embedmedia.h
@@ -34,11 +34,15 @@ public:
     static const QString URL;
     static const QString WIDTH;
 
-    EmbedMedia() {}
-    EmbedMedia(const QString &url, const int height, const int width);
-    EmbedMedia(const QByteArray &json) : JsonSerializable(json) {}
-    EmbedMedia(const QJsonObject &json) : JsonSerializable(json) {}
-    EmbedMedia(const QString &json) : JsonSerializable(json) {}
+    EmbedMedia(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    EmbedMedia(const EmbedMedia &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    EmbedMedia(const QString &url,
+               const int height,
+               const int width,
+               QObject *parent = nullptr);
+    EmbedMedia(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    EmbedMedia(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    EmbedMedia(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     Q_INVOKABLE QJsonValue getHeight() const;
     Q_INVOKABLE QJsonValue getProxyUrl() const;

--- a/bot/payloads/emoji.h
+++ b/bot/payloads/emoji.h
@@ -38,10 +38,11 @@ public:
     static const QString ANIMATED;
     static const QString AVAILABLE;
 
-    Emoji() {}
-    Emoji(const QByteArray &json) : JsonSerializable(json) {}
-    Emoji(const QJsonObject &json) : JsonSerializable(json) {}
-    Emoji(const QString &json) : JsonSerializable(json) {}
+    Emoji(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Emoji(const Emoji &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Emoji(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Emoji(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Emoji(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonArray getRoles() const;
     QJsonObject getUser() const;

--- a/bot/payloads/gatewaypayload.h
+++ b/bot/payloads/gatewaypayload.h
@@ -34,9 +34,11 @@ public:
     static const QString S;
     static const QString T;
 
-    GatewayPayload() {}
-    GatewayPayload(const QJsonObject &json) : JsonSerializable(json) {}
-    GatewayPayload(const QString &json) : JsonSerializable(json) {}
+    GatewayPayload(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    GatewayPayload(const GatewayPayload &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    GatewayPayload(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GatewayPayload(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GatewayPayload(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonObject getD() const;
     QJsonValue getV() const;

--- a/bot/payloads/guild.h
+++ b/bot/payloads/guild.h
@@ -108,10 +108,11 @@ public:
     static const QString APPROXIMATE_MEMBER_COUNT;
     static const QString APPROXIMATE_PRESENCE_COUNT;
 
-    Guild() {}
-    Guild(const QByteArray &json) : JsonSerializable(json) {}
-    Guild(const QJsonObject &json) : JsonSerializable(json) {}
-    Guild(const QString &json) : JsonSerializable(json) {}
+    Guild(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Guild(const Guild &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Guild(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Guild(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Guild(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonArray getChannels() const;
     QJsonArray getEmojis() const;

--- a/bot/payloads/guildmember.h
+++ b/bot/payloads/guildmember.h
@@ -37,10 +37,11 @@ public:
     static const QString DEAF;
     static const QString MUTE;
 
-    GuildMember() {}
-    GuildMember(const QByteArray &json) : JsonSerializable(json) {}
-    GuildMember(const QJsonObject &json) : JsonSerializable(json) {}
-    GuildMember(const QString &json) : JsonSerializable(json) {}
+    GuildMember(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    GuildMember(const GuildMember &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    GuildMember(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GuildMember(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GuildMember(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonArray getRoles() const;
     QJsonObject getUser() const;

--- a/bot/payloads/guildroledelete.h
+++ b/bot/payloads/guildroledelete.h
@@ -31,10 +31,11 @@ public:
     static const QString GUILD_ID;
     static const QString ROLE_ID;
 
-    GuildRoleDelete() {}
-    GuildRoleDelete(const QByteArray &json) : JsonSerializable(json) {}
-    GuildRoleDelete(const QJsonObject &json) : JsonSerializable(json) {}
-    GuildRoleDelete(const QString &json) : JsonSerializable(json) {}
+    GuildRoleDelete(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    GuildRoleDelete(const GuildRoleDelete &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    GuildRoleDelete(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GuildRoleDelete(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GuildRoleDelete(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getGuildId() const;
     QJsonValue getRoleId() const;

--- a/bot/payloads/guildroleupdate.h
+++ b/bot/payloads/guildroleupdate.h
@@ -34,10 +34,11 @@ public:
     static const QString GUILD_ID;
     static const QString ROLE;
 
-    GuildRoleUpdate() {}
-    GuildRoleUpdate(const QByteArray &json) : JsonSerializable(json) {}
-    GuildRoleUpdate(const QJsonObject &json) : JsonSerializable(json) {}
-    GuildRoleUpdate(const QString &json) : JsonSerializable(json) {}
+    GuildRoleUpdate(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    GuildRoleUpdate(const GuildRoleUpdate &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    GuildRoleUpdate(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GuildRoleUpdate(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    GuildRoleUpdate(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getGuildId() const;
     QJsonObject getRole() const;

--- a/bot/payloads/heartbeat.h
+++ b/bot/payloads/heartbeat.h
@@ -34,10 +34,18 @@ public:
     static const QString D;
     static const QString OP;
 
-    Heartbeat() { setOp(GatewayEvent::HEARTBEAT); }
-    Heartbeat(const QJsonObject &json) : JsonSerializable(json) { setOp(GatewayEvent::HEARTBEAT); }
-    Heartbeat(const QString &json) : JsonSerializable(json) { setOp(GatewayEvent::HEARTBEAT); }
-    Heartbeat(const QByteArray &json) : JsonSerializable(json) { setOp(GatewayEvent::HEARTBEAT); }
+    Heartbeat(QObject *parent = nullptr) : JsonSerializable(parent) {
+        setOp(GatewayEvent::HEARTBEAT);
+    }
+    Heartbeat(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {
+        setOp(GatewayEvent::HEARTBEAT);
+    }
+    Heartbeat(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {
+        setOp(GatewayEvent::HEARTBEAT);
+    }
+    Heartbeat(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {
+        setOp(GatewayEvent::HEARTBEAT);
+    }
 
 
     QJsonValue getD() const;

--- a/bot/payloads/hello.h
+++ b/bot/payloads/hello.h
@@ -31,10 +31,11 @@ class Hello : public JsonSerializable
 public:
     static const QString HEARTBEAT_INTERVAL;
 
-    Hello() {}
-    Hello(const QByteArray &json) : JsonSerializable(json) {}
-    Hello(const QJsonObject &json) : JsonSerializable(json) {}
-    Hello(const QString &json) : JsonSerializable(json) {}
+    Hello(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Hello(const Hello &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Hello(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Hello(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Hello(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     int getHeartbeatInterval();
     void setHeartbeatInterval(int interval);

--- a/bot/payloads/identify.h
+++ b/bot/payloads/identify.h
@@ -38,10 +38,11 @@ public:
     static const QString GUILD_SUBSCRIPTIONS;
     static const QString INTENTS;
 
-    Identify() {}
-    Identify(const QByteArray &json) : JsonSerializable(json) {}
-    Identify(const QJsonObject &json) : JsonSerializable(json) {}
-    Identify(const QString &json) : JsonSerializable(json) {}
+    Identify(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Identify(const Identify &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Identify(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Identify(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Identify(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonArray getShard() const;
     QJsonObject getPresence() const;

--- a/bot/payloads/identifyproperties.cpp
+++ b/bot/payloads/identifyproperties.cpp
@@ -25,9 +25,11 @@ const QString IdentifyProperties::OS = "$os";
 const QString IdentifyProperties::BROWSER = "$browser";
 const QString IdentifyProperties::DEVICE = "$device";
 
-IdentifyProperties::IdentifyProperties() {
+IdentifyProperties::IdentifyProperties(QObject *parent) : JsonSerializable(parent) {
     _jsonObject[OS] = $os;
+
     _jsonObject[BROWSER] = $browser;
+
     _jsonObject[DEVICE] = $device;
 }
 

--- a/bot/payloads/identifyproperties.h
+++ b/bot/payloads/identifyproperties.h
@@ -35,10 +35,11 @@ public:
     static const QString BROWSER;
     static const QString DEVICE;
 
-    IdentifyProperties();
-    IdentifyProperties(const QByteArray &json) : JsonSerializable(json) {}
-    IdentifyProperties(const QJsonObject &json) : JsonSerializable(json) {}
-    IdentifyProperties(const QString &json) : JsonSerializable(json) {}
+    IdentifyProperties(QObject *parent = nullptr);
+    IdentifyProperties(const IdentifyProperties &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    IdentifyProperties(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    IdentifyProperties(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    IdentifyProperties(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getOS() const;
     QJsonValue getBrowser() const;

--- a/bot/payloads/invalidsession.h
+++ b/bot/payloads/invalidsession.h
@@ -31,10 +31,11 @@ public:
     static const QString D;
     static const QString OP;
 
-    InvalidSession() {}
-    InvalidSession(const QByteArray &json) : JsonSerializable(json) {}
-    InvalidSession(const QJsonObject &json) : JsonSerializable(json) {}
-    InvalidSession(const QString &json) : JsonSerializable(json) {}
+    InvalidSession(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    InvalidSession(const InvalidSession &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    InvalidSession(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    InvalidSession(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    InvalidSession(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getD() const;
     QJsonValue getOP() const;

--- a/bot/payloads/jsonserializable.cpp
+++ b/bot/payloads/jsonserializable.cpp
@@ -21,6 +21,14 @@
 #include "jsonserializable.h"
 
 
+JsonSerializable::JsonSerializable(const JsonSerializable &other, QObject *parent) : QObject(parent) {
+    if (this == &other) {
+        return;
+    }
+
+    _jsonObject = other._jsonObject;
+}
+
 JsonSerializable::JsonSerializable(const QJsonObject &json, QObject *parent) : QObject(parent) {
     _jsonObject = json;
 }
@@ -31,6 +39,17 @@ JsonSerializable::JsonSerializable(const QString &json, QObject *parent) : QObje
 
 JsonSerializable::JsonSerializable(const QByteArray &json, QObject *parent) : QObject(parent) {
     _jsonObject = fromByteArray(json);
+}
+
+JsonSerializable&
+JsonSerializable::operator=(const JsonSerializable &other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    _jsonObject = other._jsonObject;
+
+    return *this;
 }
 
 void

--- a/bot/payloads/jsonserializable.h
+++ b/bot/payloads/jsonserializable.h
@@ -36,12 +36,11 @@ protected:
 
 public:
     JsonSerializable(QObject *parent = nullptr) : QObject(parent) {}
-    JsonSerializable(const JsonSerializable &other, QObject *parent = nullptr) : QObject(parent) {
-        _jsonObject = other._jsonObject;
-    }
+    JsonSerializable(const JsonSerializable &other, QObject *parent = nullptr);
     JsonSerializable(const QByteArray &json, QObject *parent = nullptr);
     JsonSerializable(const QJsonObject &json, QObject *parent = nullptr);
-    JsonSerializable(const QString &json, QObject *parent = nullptr);
+    JsonSerializable(const QString &json, QObject *parent = nullptr);    
+    JsonSerializable &operator=(const JsonSerializable &other);
     ~JsonSerializable() {}
 
     QByteArray toByteArray();

--- a/bot/payloads/message.h
+++ b/bot/payloads/message.h
@@ -54,10 +54,11 @@ public:
     static const QString MESSAGE_REFERENCE;
     static const QString FLAGS;
 
-    Message() {}
-    Message(const QByteArray &json) : JsonSerializable(json) {}
-    Message(const QJsonObject &json) : JsonSerializable(json) {}
-    Message(const QString &json) : JsonSerializable(json) {}
+    Message(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Message(const Message &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Message(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Message(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Message(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonArray getAttachments() const;
     QJsonArray getEmbeds() const;

--- a/bot/payloads/messageactivity.h
+++ b/bot/payloads/messageactivity.h
@@ -32,10 +32,11 @@ public:
     static const QString PARTY_ID;
     static const QString TYPE;
 
-    MessageActivity() {}
-    MessageActivity(const QByteArray &json) : JsonSerializable(json) {}
-    MessageActivity(const QJsonObject &json) : JsonSerializable(json) {}
-    MessageActivity(const QString &json) : JsonSerializable(json) {}
+    MessageActivity(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    MessageActivity(const MessageActivity &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    MessageActivity(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    MessageActivity(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    MessageActivity(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getPartyId() const;
     QJsonValue getType() const;

--- a/bot/payloads/messageapplication.h
+++ b/bot/payloads/messageapplication.h
@@ -35,10 +35,11 @@ public:
     static const QString NAME;
     static const QString ICON;
 
-    MessageApplication() {}
-    MessageApplication(const QByteArray &json) : JsonSerializable(json) {}
-    MessageApplication(const QJsonObject &json) : JsonSerializable(json) {}
-    MessageApplication(const QString &json) : JsonSerializable(json) {}
+    MessageApplication(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    MessageApplication(const MessageApplication &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    MessageApplication(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    MessageApplication(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    MessageApplication(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getCoverImage() const;
     QJsonValue getDescription() const;

--- a/bot/payloads/messagereference.h
+++ b/bot/payloads/messagereference.h
@@ -33,10 +33,11 @@ public:
     static const QString GUILD_ID;
     static const QString MESSAGE_ID;
 
-    MessageReference() {}
-    MessageReference(const QByteArray &json) : JsonSerializable(json) {}
-    MessageReference(const QJsonObject &json) : JsonSerializable(json) {}
-    MessageReference(const QString &json) : JsonSerializable(json) {}
+    MessageReference(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    MessageReference(const MessageReference &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    MessageReference(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    MessageReference(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    MessageReference(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getChannelId() const;
     QJsonValue getGuildId() const;

--- a/bot/payloads/permissionoverwrite.h
+++ b/bot/payloads/permissionoverwrite.h
@@ -34,10 +34,11 @@ public:
     static const QString ALLOW;
     static const QString DENY;
 
-    PermissionOverwrite() {}
-    PermissionOverwrite(const QByteArray &json) : JsonSerializable(json) {}
-    PermissionOverwrite(const QJsonObject &json) : JsonSerializable(json) {}
-    PermissionOverwrite(const QString &json) : JsonSerializable(json) {}
+    PermissionOverwrite(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    PermissionOverwrite(const PermissionOverwrite &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    PermissionOverwrite(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    PermissionOverwrite(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    PermissionOverwrite(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getAllow() const;
     QJsonValue getDeny() const;

--- a/bot/payloads/presenceupdate.h
+++ b/bot/payloads/presenceupdate.h
@@ -39,10 +39,11 @@ public:
     static const QString PREMIUM_SINCE;
     static const QString NICK;
 
-    PresenceUpdate() {}
-    PresenceUpdate(const QByteArray &json) : JsonSerializable(json) {}
-    PresenceUpdate(const QJsonObject &json) : JsonSerializable(json) {}
-    PresenceUpdate(const QString &json) : JsonSerializable(json) {}
+    PresenceUpdate(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    PresenceUpdate(const PresenceUpdate &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    PresenceUpdate(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    PresenceUpdate(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    PresenceUpdate(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonArray getActivities() const;
     QJsonArray getRoles() const;

--- a/bot/payloads/ratelimit.h
+++ b/bot/payloads/ratelimit.h
@@ -33,10 +33,11 @@ public:
     static const QString MESSAGE;
     static const QString RETRY_AFTER;
 
-    RateLimit() {}
-    RateLimit(const QByteArray &json) : JsonSerializable(json) {}
-    RateLimit(const QJsonObject &json) : JsonSerializable(json) {}
-    RateLimit(const QString &json) : JsonSerializable(json) {}
+    RateLimit(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    RateLimit(const RateLimit &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    RateLimit(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    RateLimit(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    RateLimit(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getGlobal() const;
     QJsonValue getMessage() const;

--- a/bot/payloads/reaction.h
+++ b/bot/payloads/reaction.h
@@ -32,10 +32,11 @@ public:
     static const QString COUNT;
     static const QString ME;
 
-    Reaction() {}
-    Reaction(const QByteArray &json) : JsonSerializable(json) {}
-    Reaction(const QJsonObject &json) : JsonSerializable(json) {}
-    Reaction(const QString &json) : JsonSerializable(json) {}
+    Reaction(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Reaction(const Reaction &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Reaction(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Reaction(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Reaction(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonObject getEmoji() const;
     QJsonValue getCount() const;

--- a/bot/payloads/ready.h
+++ b/bot/payloads/ready.h
@@ -36,10 +36,11 @@ public:
     static const QString SESSION_ID;
     static const QString SHARD;
 
-    Ready() {}
-    Ready(const QByteArray &json) : JsonSerializable(json) {}
-    Ready(const QJsonObject &json) : JsonSerializable(json) {}
-    Ready(const QString &json) : JsonSerializable(json) {}
+    Ready(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Ready(const Ready &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    Ready(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Ready(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Ready(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonArray getShard() const;
     QJsonArray getGuilds() const;

--- a/bot/payloads/resume.h
+++ b/bot/payloads/resume.h
@@ -33,10 +33,10 @@ public:
     static const QString SESSION_ID;
     static const QString SEQ;
 
-    Resume() {}
-    Resume(const QByteArray &json) : JsonSerializable(json) {}
-    Resume(const QJsonObject &json) : JsonSerializable(json) {}
-    Resume(const QString &json) : JsonSerializable(json) {}
+    Resume(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    Resume(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Resume(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Resume(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getSeq()const;
     QJsonValue getSessionId() const;

--- a/bot/payloads/role.cpp
+++ b/bot/payloads/role.cpp
@@ -30,16 +30,6 @@ const QString Role::PERMISSIONS = "permissions";
 const QString Role::MANAGED = "managed";
 const QString Role::MENTIONABLE = "mentionable";
 
-Role
-&Role::operator=(const Role &other) {
-    if (this == &other) {
-        return *this;
-    }
-
-    _jsonObject = other._jsonObject;
-
-    return *this;
-}
 
 QJsonValue
 Role::getId() const {

--- a/bot/payloads/role.h
+++ b/bot/payloads/role.h
@@ -44,7 +44,6 @@ public:
     Role(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
     Role(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
-    Role &operator=(const Role &other);
 
     QJsonValue getColor() const;
     QJsonValue getHoist() const;

--- a/bot/payloads/role.h
+++ b/bot/payloads/role.h
@@ -43,7 +43,15 @@ public:
     Role(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
     Role(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
     Role(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    Role& operator=(const Role &other) {
+        if (this == &other) {
+            return *this;
+        }
 
+        _jsonObject = other._jsonObject;
+
+        return *this;
+    }
 
     QJsonValue getColor() const;
     QJsonValue getHoist() const;

--- a/bot/payloads/updatestatus.h
+++ b/bot/payloads/updatestatus.h
@@ -34,10 +34,11 @@ public:
     static const QString SINCE;
     static const QString STATUS;
 
-    UpdateStatus() {}
-    UpdateStatus(const QByteArray &json) : JsonSerializable(json) {}
-    UpdateStatus(const QJsonObject &json) : JsonSerializable(json) {}
-    UpdateStatus(const QString &json) : JsonSerializable(json) {}
+    UpdateStatus(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    UpdateStatus(const UpdateStatus &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    UpdateStatus(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    UpdateStatus(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    UpdateStatus(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonObject getGame() const;
     QJsonValue getAfk() const;

--- a/bot/payloads/user.h
+++ b/bot/payloads/user.h
@@ -43,10 +43,11 @@ public:
     static const QString PREMIUM_TYPE;
     static const QString PUBLIC_FLAGS;
 
-    User() {}
-    User(const QByteArray &json) : JsonSerializable(json) {}
-    User(const QJsonObject &json) : JsonSerializable(json) {}
-    User(const QString &json) : JsonSerializable(json) {}
+    User(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    User(const User &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    User(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    User(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    User(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonValue getAvatar() const;
     QJsonValue getBot() const;

--- a/bot/payloads/voicestate.h
+++ b/bot/payloads/voicestate.h
@@ -41,10 +41,11 @@ public:
     static const QString SELF_STREAM;
     static const QString SUPPRESS;
 
-    VoiceState() {}
-    VoiceState(const QByteArray &json) : JsonSerializable(json) {}
-    VoiceState(const QJsonObject &json) : JsonSerializable(json) {}
-    VoiceState(const QString &json) : JsonSerializable(json) {}
+    VoiceState(QObject *parent = nullptr) : JsonSerializable(parent) {}
+    VoiceState(const VoiceState &other, QObject *parent = nullptr) : JsonSerializable(other, parent) {}
+    VoiceState(const QByteArray &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    VoiceState(const QJsonObject &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
+    VoiceState(const QString &json, QObject *parent = nullptr) : JsonSerializable(json, parent) {}
 
     QJsonObject getMember() const;
     QJsonValue getChannelId() const;

--- a/bot/qml/qmlfactory.cpp
+++ b/bot/qml/qmlfactory.cpp
@@ -107,6 +107,8 @@ QmlFactory::buildQmlFactory(QSharedPointer<QQmlEngine> engine, const DatabaseCon
 
     engine->globalObject().setProperty("_factory", factory);
 
+    engine->evaluate("function TempFile(path, mode = 1) { return _factory.createObject(\"TempFile\", { filePath: path, openMode: mode }); }");
+
     engine->evaluate("function File(path, mode = 1) { return _factory.createObject(\"File\", { filePath: path, openMode: mode }); }");
 
     engine->evaluate("function Http() { return _factory.createObject(\"Http\", {}); }");
@@ -152,6 +154,20 @@ QmlFactory::createFile(const QVariantMap& arguments) {
             qvariant_cast<OpenMode::Mode>(arguments.value("openMode", OpenMode::ReadWrite));
 
     return new File(filePath, openMode);
+}
+
+QObject*
+QmlFactory::createTempFile(const QVariantMap& arguments) {
+    QString filePath = arguments.value("filePath", "").toString();
+
+    if (filePath.isEmpty()) {
+        return new TempFile;
+    }
+
+    OpenMode::Mode openMode =
+            qvariant_cast<OpenMode::Mode>(arguments.value("openMode", OpenMode::ReadWrite));
+
+    return new TempFile(filePath, openMode);
 }
 
 QObject*

--- a/bot/qml/qmlfactory.h
+++ b/bot/qml/qmlfactory.h
@@ -35,6 +35,7 @@ class QmlFactory : public QObject
     DatabaseContext _databaseContext;
 
     QObject *createFile(const QVariantMap& arguments);
+    QObject *createTempFile(const QVariantMap& arguments);
     QObject *createSqlQuery(const QVariantMap& arguments);
     QObject *createEmbed(const QVariantMap &arguments);
     QObject *createEmbedField(const QVariantMap &arguments);

--- a/bot/qml/tempfile.h
+++ b/bot/qml/tempfile.h
@@ -42,6 +42,20 @@ public:
         }
     }
 
+    TempFile(const QString &fileName, const OpenMode::Mode openMode, QObject *parent = nullptr) : File{parent} {
+        if (!fileName.isEmpty()) {
+            _fileName = QString("%1/%2")
+                    .arg(makeTempPath())
+                    .arg(fileName);
+        } else {
+            _fileName = QString("%1/%2")
+                    .arg(makeTempPath())
+                    .arg(QUuid::createUuid().toString(QUuid::Id128));
+        }
+
+        _openMode = openMode;
+    }
+
     ~TempFile() {        
         QDir dir(QFileInfo(*_file.get()).absolutePath());
 


### PR DESCRIPTION
- ScriptBuilder refactor cleanup pt 1

   - scripts validated only once, not for every guild online, unless reload command issued.
   - More validation
   - 

- Gateway Bindings now require `binding_name` which functions like a command name for enabling/disabling gateway commands
   - Must be unique across all scripts, like command/script names
   - You cannot invoke binding_names via chat messages, there are only used to `.enable/.disable` etc

- General refactoring/cleanup around permissions