### PR TITLE
Logging cleanup, [date][log_level][source]:<log_entry>

### DIFF
--- a/bot/logging/logger.cpp
+++ b/bot/logging/logger.cpp
@@ -23,10 +23,6 @@
 #include <QThread>
 
 Logger::Logger(QString loggerName, QObject *parent) : QObject (parent) {
-    if (!loggerName.isEmpty()) {
-        loggerName = QString("[%1]").arg(loggerName);
-    }
-
     _loggerName = loggerName;
 }
 

--- a/bot/logging/logworker.cpp
+++ b/bot/logging/logworker.cpp
@@ -196,10 +196,10 @@ LogWorker::logEvent(Logger::LogLevel level, QString message, QString loggerName)
 
         QString dateTime = QDateTime::currentDateTime().toString("yyyy/MM/dd hh:mm:ss.zzz");
 
-        QString logString = QString("[%1]%2[%3]: %4")
+        QString logString = QString("[%1][%2][%3]: %4")
                 .arg(dateTime)
-                .arg(loggerName)
                 .arg(logLevel)
+                .arg(loggerName)                
                 .arg(message);
 
         if (consoleLoggingEnabled(level)) {


### PR DESCRIPTION
log entries now read as `[date][log_level][source]:<log_entry>`

eg.

`[2022/07/14 22:28:13.496][INFO][ScriptManager]: Loading bot script: 8ball.qml for guild_id: 873585912448180295`